### PR TITLE
fixed one-hot encoding lambda function; pickling error

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -30,7 +30,7 @@ def postprocess(x):
 
 def one_hot_encode(target):
     """
-    Desc: lambda functions can't be pickled across all platforms (dill doesn't help)
+    One hot encode with fixed 10 classes
     Args: target           - the target labels to one-hot encode
     Retn: one_hot_encoding - the OHE of this tensor
     """

--- a/datasets.py
+++ b/datasets.py
@@ -58,7 +58,6 @@ def get_CIFAR10(augment, dataroot, download):
 
     test_transform = transforms.Compose([transforms.ToTensor(), preprocess])
 
-    # removed lambda function, can't be pickled
 
     path = Path(dataroot) / "data" / "CIFAR10"
     train_dataset = datasets.CIFAR10(

--- a/datasets.py
+++ b/datasets.py
@@ -34,7 +34,6 @@ def one_hot_encode(target):
     Args: target           - the target labels to one-hot encode
     Retn: one_hot_encoding - the OHE of this tensor
     """
-    # same for both CIFAR10 ans SVHN, can be customized for later datasets
     num_classes = 10
     one_hot_encoding = F.one_hot(torch.tensor(target),num_classes)
 

--- a/datasets.py
+++ b/datasets.py
@@ -93,7 +93,6 @@ def get_SVHN(augment, dataroot, download):
 
     test_transform = transforms.Compose([transforms.ToTensor(), preprocess])
 
-    # removed lambda function, can't be pickled
 
     path = Path(dataroot) / "data" / "SVHN"
     train_dataset = datasets.SVHN(

--- a/datasets.py
+++ b/datasets.py
@@ -28,6 +28,18 @@ def postprocess(x):
     x = x * 2 ** n_bits
     return torch.clamp(x, 0, 255).byte()
 
+def one_hot_encode(target):
+    """
+    Desc: lambda functions can't be pickled across all platforms (dill doesn't help)
+    Args: target           - the target labels to one-hot encode
+    Retn: one_hot_encoding - the OHE of this tensor
+    """
+    # same for both CIFAR10 ans SVHN, can be customized for later datasets
+    num_classes = 10
+    one_hot_encoding = F.one_hot(torch.tensor(target),num_classes)
+
+    return one_hot_encoding
+
 
 def get_CIFAR10(augment, dataroot, download):
     image_shape = (32, 32, 3)
@@ -46,7 +58,7 @@ def get_CIFAR10(augment, dataroot, download):
 
     test_transform = transforms.Compose([transforms.ToTensor(), preprocess])
 
-    one_hot_encode = lambda target: F.one_hot(torch.tensor(target), num_classes)
+    # removed lambda function, can't be pickled
 
     path = Path(dataroot) / "data" / "CIFAR10"
     train_dataset = datasets.CIFAR10(
@@ -82,7 +94,7 @@ def get_SVHN(augment, dataroot, download):
 
     test_transform = transforms.Compose([transforms.ToTensor(), preprocess])
 
-    one_hot_encode = lambda target: F.one_hot(torch.tensor(target), num_classes)
+    # removed lambda function, can't be pickled
 
     path = Path(dataroot) / "data" / "SVHN"
     train_dataset = datasets.SVHN(


### PR DESCRIPTION
### Fixed ForkingPickler() Error from lambda function in get_CIFAR10() and get_SVHN() in datasets.py

**Noted bug**: 
```
AttributeError: Can't pickle local object 'get_CIFAR10.__init__.<locals>.<lambda>'
```
or
```
AttributeError: Can't pickle local object 'get_SVHN.__init__.<locals>.<lambda>'
```

**Description**:
Mac and Windows machines cannot pickle a lambda function which is currently how the master branch handles one-hot encoding of the CIFAR-10 and SVHN datasets.

Added a one_hot_encode() function (same name as target_transform value) which performs the same torch.nn.one_hot() call as the original lambda function in datasets.py

**Tested Bug Environments**:
* MacOS with Python 3.8.5
* Windows 10 with Python 3.8.5

